### PR TITLE
Fix/node 4x 5x compatibility

### DIFF
--- a/lib/Checker.class.js
+++ b/lib/Checker.class.js
@@ -6,7 +6,8 @@ const EnvironmentVariable = require('./EnvironmentVariable.class');
 const YAML = require('yamljs');
 
 class Checker {
-	constructor(options = {}) {
+	constructor(options) {
+		options = options || {};
 		this.specLocation = path.resolve(options.specLocation || 'env.yaml');
 		this.autoLoad = options.hasOwnProperty('autoLoad') ? options.autoLoad : true;
 		// auto-load the spec if autoLoad has not been set to false

--- a/lib/EnvironmentVariable.class.js
+++ b/lib/EnvironmentVariable.class.js
@@ -37,7 +37,7 @@ class EnvironmentVariable {
 				'number',
 				'boolean',
 				'any'
-			].includes(config.type);
+			].indexOf(config.type) >= 0;
 			
 			if(isSet && isAcceptableValue && isValidType) {
 				return config.type

--- a/lib/EnvironmentVariable.class.js
+++ b/lib/EnvironmentVariable.class.js
@@ -7,7 +7,8 @@ const checkConvertable = require('./is-convertible');
 
 // Class Definition
 class EnvironmentVariable {
-	constructor(variableName, config = {}) {
+	constructor(variableName, config) {
+		config = config || {};
 
 		this.variableName = (() => {
 			if (!variableName || typeof variableName !== 'string'){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "check-environment",
-  "version": "0.0.2",
+  "version": "0.0.21",
   "description": "",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Removes use of:
- default values for parameters
- Array.includes()

This allows tests to pass on Node 4.x and 5.x